### PR TITLE
[WIP] Fix Calculations for SWT Near Minimums

### DIFF
--- a/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.AL
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
         //example from page
         [TestCase(850, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 31.20)]
         //verified with paycheck city

--- a/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
@@ -7,8 +7,7 @@ namespace CertiPay.Taxes.State.Tests.AL
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
         [TestCase(1, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2, 0)]
         //example from page

--- a/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AL/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.AL
 {
@@ -22,6 +23,16 @@ namespace CertiPay.Taxes.State.Tests.AL
             var result = table.Calculate(grossWages, freq, federalWithholding, status, dependentAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, 41.40, FilingStatus.Married, 2)]
+        public void NegativeValues_Alabama_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, decimal federalWithholding, Alabama.FilingStatus status, int dependentAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.AL, year: 2017) as Alabama.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, federalWithholding, status, dependentAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -27,6 +27,8 @@ namespace CertiPay.Taxes.State.Tests.AR
             var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;
 
             var result = taxTable.Calculate(grossWages, frequency, exemptions);
+
+            Assert.AreEqual(Decimal.Zero, result);
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -1,7 +1,8 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
-namespace CertiPay.Taxes.State.Tests.AK
+namespace CertiPay.Taxes.State.Tests.AR
 {
     [TestFixture]
     public class TaxTable2017Tests
@@ -17,6 +18,15 @@ namespace CertiPay.Taxes.State.Tests.AK
             var result = taxTable.Calculate(grossWages, frequency, exemptions);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, 25, 5)]
+        public void Ensure_Guards_For_Wage_Ranges(PayrollFrequency frequency, Decimal grossWages, int exemptions)
+        {
+            var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;
+
+            var result = taxTable.Calculate(grossWages, frequency, exemptions);
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -22,6 +22,7 @@ namespace CertiPay.Taxes.State.Tests.AR
 
         [Test]
         [TestCase(PayrollFrequency.Weekly, 25, 5)]
+        [TestCase(PayrollFrequency.Annually, -2500, 5)]
         public void Ensure_Guards_For_Wage_Ranges(PayrollFrequency frequency, Decimal grossWages, int exemptions)
         {
             var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.AR
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 2, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, 2, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, 2, 0)]
         [TestCase(2127, PayrollFrequency.Monthly, 2, 61.35)]
         [TestCase(1250, PayrollFrequency.Weekly, 2, 64.25)]
         [TestCase(954, PayrollFrequency.Weekly, 1, 44.38)]

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -24,7 +24,7 @@ namespace CertiPay.Taxes.State.Tests.AR
 
         [Test]
         [TestCase(PayrollFrequency.Weekly, 25, 5)]
-        [TestCase(PayrollFrequency.Annually, -2500, 5)]
+        [TestCase(PayrollFrequency.Annually, 2500, 5)]
         public void Ensure_Guards_For_Wage_Ranges(PayrollFrequency frequency, Decimal grossWages, int exemptions)
         {
             var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;

--- a/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AR/TaxTable2017Tests.cs
@@ -7,15 +7,14 @@ namespace CertiPay.Taxes.State.Tests.AR
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, 2, 0)]
+        [Test]       
         [TestCase(0, PayrollFrequency.Monthly, 2, 0)]
         [TestCase(1, PayrollFrequency.Monthly, 2, 0)]
         [TestCase(2127, PayrollFrequency.Monthly, 2, 61.35)]
         [TestCase(1250, PayrollFrequency.Weekly, 2, 64.25)]
         [TestCase(954, PayrollFrequency.Weekly, 1, 44.38)]
         public void AR_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency frequency, int exemptions, decimal expected)
-        {
+        {            
             var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;
 
             var result = taxTable.Calculate(grossWages, frequency, exemptions);
@@ -34,5 +33,15 @@ namespace CertiPay.Taxes.State.Tests.AR
 
             Assert.AreEqual(Decimal.Zero, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 2)]
+        public void NegativeValues_AR_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency frequency, int exemptions)
+        {
+            var taxTable = TaxTables.GetForState(StateOrProvince.AR, year: 2017) as Arkansas.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => taxTable.Calculate(grossWages, frequency, exemptions));
+        }
     }
+
 }

--- a/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
@@ -7,7 +7,10 @@ namespace CertiPay.Taxes.State.Tests.AZ
     public class TaxTable2017Tests
     {       
          
-        [Test]        
+        [Test]
+        [TestCase(-1, Arizona.TaxRate.FivePointOnePercent, 0)]
+        [TestCase(0, Arizona.TaxRate.FivePointOnePercent, 0)]
+        [TestCase(1, Arizona.TaxRate.FivePointOnePercent, 0)]
         [TestCase(1500, Arizona.TaxRate.FivePointOnePercent, 76.5)]      
         public void AZ_2017_Checks_And_Balances(decimal grossWages, Arizona.TaxRate rate, decimal expected)
         {

--- a/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
@@ -10,7 +10,7 @@ namespace CertiPay.Taxes.State.Tests.AZ
         [Test]
         [TestCase(-1, Arizona.TaxRate.FivePointOnePercent, 0)]
         [TestCase(0, Arizona.TaxRate.FivePointOnePercent, 0)]
-        [TestCase(1, Arizona.TaxRate.FivePointOnePercent, 0)]
+        [TestCase(1, Arizona.TaxRate.FivePointOnePercent, 0.051)]
         [TestCase(1500, Arizona.TaxRate.FivePointOnePercent, 76.5)]      
         public void AZ_2017_Checks_And_Balances(decimal grossWages, Arizona.TaxRate rate, decimal expected)
         {

--- a/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
@@ -22,7 +22,7 @@ namespace CertiPay.Taxes.State.Tests.AZ
         }
 
         [Test]
-        [TestCase(-1, Arizona.TaxRate.FivePointOnePercent, 0)]
+        [TestCase(-1, Arizona.TaxRate.FivePointOnePercent)]
         public void NegativeValues_AZ_2017_Checks_And_Balances(decimal grossWages, Arizona.TaxRate rate)
         {
             var taxTable = TaxTables.GetForState(StateOrProvince.AZ, 2017) as Arizona.TaxTable;

--- a/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/AZ/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.AZ
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.AZ
     public class TaxTable2017Tests
     {       
          
-        [Test]
-        [TestCase(-1, Arizona.TaxRate.FivePointOnePercent, 0)]
+        [Test]        
         [TestCase(0, Arizona.TaxRate.FivePointOnePercent, 0)]
         [TestCase(1, Arizona.TaxRate.FivePointOnePercent, 0.051)]
         [TestCase(1500, Arizona.TaxRate.FivePointOnePercent, 76.5)]      
@@ -20,5 +20,15 @@ namespace CertiPay.Taxes.State.Tests.AZ
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, Arizona.TaxRate.FivePointOnePercent, 0)]
+        public void NegativeValues_AZ_2017_Checks_And_Balances(decimal grossWages, Arizona.TaxRate rate)
+        {
+            var taxTable = TaxTables.GetForState(StateOrProvince.AZ, 2017) as Arizona.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => taxTable.Calculate(grossWages, rate));
+        }
+
     }
 }

--- a/CertiPay.Taxes.State.Tests/CA/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/CA/TaxTableTests.cs
@@ -9,6 +9,9 @@ namespace CertiPay.Taxes.State.Tests.CA
     public class TaxTableTests
     {
         [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1, 1, 0)]
+        [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 1, 1, 0)]
+        [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 1, 1, 0)]
         //verified with pcc... didn't match up with documented examples... was a couple cents off
         [TestCase(PayrollFrequency.Weekly, 210, FilingStatus.Single, 1, 1, 0)]
         //specifically this one, should be 3.51 according to the documentation

--- a/CertiPay.Taxes.State.Tests/CA/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/CA/TaxTableTests.cs
@@ -8,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.CA
 
     public class TaxTableTests
     {
-        [Test]
-        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1, 1, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 1, 1, 0)]
         [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 1, 1, 0)]
         //verified with pcc... didn't match up with documented examples... was a couple cents off
@@ -24,6 +23,15 @@ namespace CertiPay.Taxes.State.Tests.CA
             var result = table.Calculate(grossWages, frequency, status, allowances, deductions);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1, 1)]
+        public void NegativeValues_California_2017_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus status, int allowances, int deductions)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.CA, year: 2017) as California.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, status, allowances, deductions));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/CO/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/CO/TaxTableTests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.CO
     public class TaxTableTests
     {
         [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1, 0)]
+        [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 1, 0)]
+        [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 1, 0)]
         //verified with pcc
         [TestCase(PayrollFrequency.Weekly, 210, FilingStatus.Single, 1, 4.00)]
         [TestCase(PayrollFrequency.Weekly, 1250, FilingStatus.Married, 2, 43.00)]

--- a/CertiPay.Taxes.State.Tests/CO/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/CO/TaxTableTests.cs
@@ -7,8 +7,7 @@ namespace CertiPay.Taxes.State.Tests.CO
 
     public class TaxTableTests
     {
-        [Test]
-        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1, 0)]
+        [Test]       
         [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 1, 0)]
         [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 1, 0)]
         //verified with pcc
@@ -22,6 +21,15 @@ namespace CertiPay.Taxes.State.Tests.CO
             var result = table.Calculate(grossWages, frequency, status, allowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 1)]
+        public void NegativeValues_Colorado_2017_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus status, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.CO, year: 2017) as Colorado.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, status, allowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/CT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/CT/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.CT
     {
         //verified with PCC unless noted otherwise
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
         //verified by hand
         [TestCase(1500, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 9.00)]
         [TestCase(1500, PayrollFrequency.Monthly, Connecticut.WithholdingCode.B, 1, 0.00)]

--- a/CertiPay.Taxes.State.Tests/CT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/CT/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.CT
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.CT
     public class TaxTable2017Tests
     {
         //verified with PCC unless noted otherwise
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1, 0)]
         //verified by hand
@@ -31,5 +31,16 @@ namespace CertiPay.Taxes.State.Tests.CT
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, Connecticut.WithholdingCode.A, 1)]
+        public void NegativeValues_CT_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, Connecticut.WithholdingCode employeeCode, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.CT, year: 2017) as Connecticut.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, employeeCode, personalAllowances));
+        }
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/DE/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/DE/TaxTableTests.cs
@@ -6,8 +6,7 @@ namespace CertiPay.Taxes.State.Tests.DE
 {
     public class TaxTableTests
     {
-        [Test]
-        [TestCase(PayrollFrequency.SemiMonthly, -1, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.SemiMonthly, 0, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1825, Delaware.FilingStatus.MarriedFilingJointly, 2, 60.99d)]
@@ -20,5 +19,17 @@ namespace CertiPay.Taxes.State.Tests.DE
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, Delaware.FilingStatus.MarriedFilingJointly, 2)]
+        public void NegativeValues_DEChecks_And_Balances(PayrollFrequency frequency, Decimal grossWages, Delaware.FilingStatus filingStatus, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.DE, year: 2017) as Delaware.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, filingStatus, allowances));
+        }
+
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/DE/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/DE/TaxTableTests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.DE
     public class TaxTableTests
     {
         [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 0, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 1, Delaware.FilingStatus.MarriedFilingJointly, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1825, Delaware.FilingStatus.MarriedFilingJointly, 2, 60.99d)]
         [TestCase(PayrollFrequency.BiWeekly, 2500, Delaware.FilingStatus.Single, 2, 109.19d)]
         public void DEChecks_And_Balances(PayrollFrequency frequency, Decimal grossWages, Delaware.FilingStatus filingStatus, int allowances, Decimal expected)

--- a/CertiPay.Taxes.State.Tests/GA/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/GA/TaxTable2016Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests
 {
@@ -19,6 +20,8 @@ namespace CertiPay.Taxes.State.Tests
         }
 
         [Test]
+        [TestCase(0, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0, 49.17)]
         [TestCase(3000, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0, 139.17)]
         [TestCase(1733.40, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0, 85.16)]
@@ -44,6 +47,15 @@ namespace CertiPay.Taxes.State.Tests
             var result = table.Calculate(grossWages, freq, status, personalAllowances, dependentAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        public void NegativeValues_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus status, int personalAllowances, int dependentAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.GA, year: 2016) as Georgia.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, status, personalAllowances, dependentAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/HI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/HI/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.HI
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
         //pulled from documentation
         [TestCase(375, PayrollFrequency.Weekly, FilingStatus.Single, 3, 15.30)]
         //pcc

--- a/CertiPay.Taxes.State.Tests/HI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/HI/TaxTable2017Tests.cs
@@ -1,13 +1,13 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.HI
 {
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 3, 0)]
         //pulled from documentation
@@ -23,5 +23,17 @@ namespace CertiPay.Taxes.State.Tests.HI
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 3)]
+        public void NegativeValues_Hawaii_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.HI, year: 2017) as Hawaii.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, allowances, filingStatus));
+        }
+
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/IA/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IA/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.IA
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
+        [TestCase(0, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
+        [TestCase(1, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
         //pulled from documentation
         [TestCase(740, PayrollFrequency.BiWeekly, 5.12, 3, 17.48)]
         [TestCase(2750, PayrollFrequency.Monthly, 98.30, 4, 102.33)]

--- a/CertiPay.Taxes.State.Tests/IA/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IA/TaxTable2017Tests.cs
@@ -1,13 +1,13 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.IA
 {
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
         [TestCase(1, PayrollFrequency.BiWeekly, 5.12, 3, 0)]
         //pulled from documentation
@@ -23,5 +23,16 @@ namespace CertiPay.Taxes.State.Tests.IA
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, 5.12, 3)]
+        public void Iowa_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, decimal federalWithholding, int exemptions)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.IA, year: 2017) as Iowa.TaxTable;
+            
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, federalWithholding, exemptions));
+        }
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/ID/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ID/TaxTable2017Tests.cs
@@ -10,6 +10,9 @@ namespace CertiPay.Taxes.State.Tests.ID
     {     
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
         [TestCase(700, PayrollFrequency.Weekly, FilingStatus.Married, 4, 8)]
         public void ID_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus status, int personalAllowances, decimal expected)
         {

--- a/CertiPay.Taxes.State.Tests/ID/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ID/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.ID
 {
@@ -9,8 +10,7 @@ namespace CertiPay.Taxes.State.Tests.ID
     public class TaxTable2017Tests
     {     
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Married, 4, 0)]
         [TestCase(700, PayrollFrequency.Weekly, FilingStatus.Married, 4, 8)]
@@ -22,5 +22,15 @@ namespace CertiPay.Taxes.State.Tests.ID
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Married, 4)]
+        public void NegativeValues_ID_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus status, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.ID, year: 2017) as Idaho.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, status, personalAllowances));
+        }
+
     }
 }

--- a/CertiPay.Taxes.State.Tests/IL/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IL/TaxTable2016Tests.cs
@@ -6,8 +6,7 @@ namespace CertiPay.Taxes.State.Tests.IL
 {
     public class TaxTable2016Tests
     {
-        [Test]
-        [TestCase(PayrollFrequency.Weekly, -1, 2, 0, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.Weekly, 0, 2, 0, 0)]
         [TestCase(PayrollFrequency.Weekly, 1, 2, 0, 0)]
         [TestCase(PayrollFrequency.Weekly, 450, 2, 0, 13.74d)]
@@ -21,6 +20,15 @@ namespace CertiPay.Taxes.State.Tests.IL
             var result = table.Calculate(grossWages, frequency, basicAllowances, additionalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, 2, 0)]
+        public void NegativeValue_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, int basicAllowances, int additionalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.IL, year: 2016) as Illinois.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, basicAllowances, additionalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/IL/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IL/TaxTable2016Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.IL
     public class TaxTable2016Tests
     {
         [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, 2, 0, 0)]
+        [TestCase(PayrollFrequency.Weekly, 0, 2, 0, 0)]
+        [TestCase(PayrollFrequency.Weekly, 1, 2, 0, 0)]
         [TestCase(PayrollFrequency.Weekly, 450, 2, 0, 13.74d)]
         [TestCase(PayrollFrequency.Weekly, 875, 3, 1, 27.39d)]
         [TestCase(PayrollFrequency.SemiMonthly, 875, 2, 0, 26.02d)]

--- a/CertiPay.Taxes.State.Tests/IN/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IN/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.IN
     {       
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, 5, 3, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, 5, 3, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, 5, 3, 0)]
         [TestCase(800, PayrollFrequency.Weekly, 5, 3, 19.94)]       
         public void IN_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int personalAllowances, int dependentAllowances, decimal expected)
         {

--- a/CertiPay.Taxes.State.Tests/IN/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/IN/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.IN
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.IN
     public class TaxTable2017Tests
     {       
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Weekly, 5, 3, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Weekly, 5, 3, 0)]
         [TestCase(1, PayrollFrequency.Weekly, 5, 3, 0)]
         [TestCase(800, PayrollFrequency.Weekly, 5, 3, 19.94)]       
@@ -19,6 +19,16 @@ namespace CertiPay.Taxes.State.Tests.IN
             var result = table.Calculate(grossWages, freq, personalAllowances, dependentAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, 5, 3)]
+        public void NegativeValues_IN_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int personalAllowances, int dependentAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.IN, year: 2017) as Indiana.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, personalAllowances, dependentAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/KS/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/KS/TaxTable2017Tests.cs
@@ -9,6 +9,9 @@ namespace CertiPay.Taxes.State.Tests.KS
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
+        [TestCase(0, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
+        [TestCase(1, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
         //example from documentation
         [TestCase(600, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 4.00)]
         //paycheck city verification

--- a/CertiPay.Taxes.State.Tests/KS/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/KS/TaxTable2017Tests.cs
@@ -8,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.KS
 
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
+        [Test]        
         [TestCase(0, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
         [TestCase(1, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly, 0)]
         //example from documentation
@@ -25,5 +24,16 @@ namespace CertiPay.Taxes.State.Tests.KS
 
             Assert.AreEqual(expected, result);
         }
+
+
+        [Test]
+        [TestCase(-1, 2, FilingStatus.MarriedOrHoH, PayrollFrequency.SemiMonthly)]
+        public void NegativeValues_Kansas_2017_Checks_And_Balances(Decimal grossWages, int exemptions, FilingStatus filingStatus, PayrollFrequency payrollFrequency)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.KS, year: 2017) as Kansas.TaxTable2017;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, payrollFrequency, filingStatus, exemptions));
+        }
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/KY/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/KY/TaxTable2017Tests.cs
@@ -1,14 +1,13 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
-
+using System;
 namespace CertiPay.Taxes.State.Tests.KY
 {
     [TestFixture]
     public class TaxTable2017Tests
     {       
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         //documentation verification
@@ -22,6 +21,15 @@ namespace CertiPay.Taxes.State.Tests.KY
             var result = table.Calculate(grossWages, freq, exemptions);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1)]
+        public void NegativeValues_Kentucky_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int exemptions)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.KY, year: 2017) as Kentucky.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, exemptions));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/KY/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/KY/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.KY
     {       
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         //documentation verification
         [TestCase(3020, PayrollFrequency.Monthly, 1, 147.01)]
         //paycheckcity verification

--- a/CertiPay.Taxes.State.Tests/LA/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/LA/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.LA
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.LA
     public class TaxTable2017Tests
     {
         [Test]
-        //two examples from documentation
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
+        //two examples from documentation        
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
         [TestCase(700, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 19.43)]
@@ -23,5 +23,16 @@ namespace CertiPay.Taxes.State.Tests.LA
 
             Assert.AreEqual(expected, result);
         }
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2)]
+        public void NegativeValues_Lousiana_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalExemptions, int dependents)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.LA, year: 2017) as Louisiana.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalExemptions, dependents));
+        }
+       
     }
 }

--- a/CertiPay.Taxes.State.Tests/LA/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/LA/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.LA
     {
         [Test]
         //two examples from documentation
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 0)]
         [TestCase(700, PayrollFrequency.Weekly, FilingStatus.Single, 1, 2, 19.43)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 3, 157.12)]
         //pcc verification

--- a/CertiPay.Taxes.State.Tests/MA/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MA/TaxTable2016Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.MA
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.MA
     public class Massachusetts_Tests
     {
         [Test]
-        //[TestCase(350, PayrollFrequency.Weekly, 4, 26.78, false, false, 9.51)] This was based on 2012 amounts
-        [TestCase(-1, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
+        //[TestCase(350, PayrollFrequency.Weekly, 4, 26.78, false, false, 9.51)] This was based on 2012 amounts        
         [TestCase(0, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
         [TestCase(1, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 2000, true, true, 29.75)] // Bad test case, we don't have 2k of FICA in one period
@@ -23,5 +23,15 @@ namespace CertiPay.Taxes.State.Tests.MA
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1, 2000, true, true)]
+        public void NegativeValues_MA2016_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int numExemptions, decimal FICADeductions, bool IsBlind, bool IsHoH)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.MA, year: 2016) as Massachusettes.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, FICADeductions, numExemptions, IsBlind, IsHoH));
+        }
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/MA/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MA/TaxTable2016Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.MA
     {
         [Test]
         //[TestCase(350, PayrollFrequency.Weekly, 4, 26.78, false, false, 9.51)] This was based on 2012 amounts
+        [TestCase(-1, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, 1, 2000, true, true, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 2000, true, true, 29.75)] // Bad test case, we don't have 2k of FICA in one period
         [TestCase(4000, PayrollFrequency.Monthly, 2, 2000, false, false, 172.55)] // Bad test case, we don't have 2k of FICA in one period
         [TestCase(1500, PayrollFrequency.BiWeekly, 2, 114.75, false, false, 61.98)] // FICA 93 + MEDI 21.75 => capped at $2k

--- a/CertiPay.Taxes.State.Tests/ME/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ME/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.ME
     {
         [Test]
         //Pay check city was wrong, verified by hand using examples from the withholding guide
+        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Single, 1, 25.13)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Married, 1, 0)]
         [TestCase(5000, PayrollFrequency.Monthly, FilingStatus.Single, 1, 248.81)]

--- a/CertiPay.Taxes.State.Tests/ME/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ME/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.ME
 {
@@ -8,7 +9,7 @@ namespace CertiPay.Taxes.State.Tests.ME
     {
         [Test]
         //Pay check city was wrong, verified by hand using examples from the withholding guide
-        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        
         [TestCase(0, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Single, 1, 25.13)]
@@ -23,5 +24,15 @@ namespace CertiPay.Taxes.State.Tests.ME
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1)]
+        public void Maine_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus status, int withholdingAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.ME, year: 2017) as Maine.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, status, withholdingAllowances));
+        }
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/MI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MI/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.MI
 {
@@ -8,7 +9,7 @@ namespace CertiPay.Taxes.State.Tests.MI
     {
         [Test]
         //Verified with Tax Tables
-        [TestCase(-1, PayrollFrequency.BiWeekly, 1, 1, 0)]
+        
         [TestCase(0, PayrollFrequency.BiWeekly, 1, 1, 0)]
         [TestCase(1, PayrollFrequency.BiWeekly, 1, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, 1, 1, 182.42)]
@@ -22,5 +23,15 @@ namespace CertiPay.Taxes.State.Tests.MI
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, 1, 1)]
+        public void Michigan_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int personalAllowances, int dependents)
+        {
+          var table = TaxTables.GetForState(StateOrProvince.MI, year: 2017) as Michigan.TaxTable2017;
+          
+          Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, personalAllowances, dependents));
+        }
+
     }
 }

--- a/CertiPay.Taxes.State.Tests/MI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MI/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.MI
     {
         [Test]
         //Verified with Tax Tables
+        [TestCase(-1, PayrollFrequency.BiWeekly, 1, 1, 0)]
+        [TestCase(0, PayrollFrequency.BiWeekly, 1, 1, 0)]
+        [TestCase(1, PayrollFrequency.BiWeekly, 1, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, 1, 1, 182.42)]
         [TestCase(1000, PayrollFrequency.BiWeekly, 0, 0, 42.5)]
         [TestCase(5, PayrollFrequency.BiWeekly, 2, 2, 0)]

--- a/CertiPay.Taxes.State.Tests/MN/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MN/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.MN
     {
         [Test]
         //Verified by hand
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 299.67)]
         [TestCase(500, PayrollFrequency.BiWeekly, FilingStatus.Married, 0, 8.95)]
         public void Minnesota_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances,decimal expected)

--- a/CertiPay.Taxes.State.Tests/MN/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MN/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.MN
 {
@@ -8,7 +9,7 @@ namespace CertiPay.Taxes.State.Tests.MN
     {
         [Test]
         //Verified by hand
-        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
+       
         [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Single, 1, 299.67)]
@@ -21,5 +22,17 @@ namespace CertiPay.Taxes.State.Tests.MN
 
             Assert.AreEqual(expected, result);
         }
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 1)]
+        public void NegativeValue_Minnesota_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.MN, year: 2017) as Minnesota.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
+        }
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/MO/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MO/TaxTable2017Tests.cs
@@ -8,9 +8,8 @@ namespace CertiPay.Taxes.State.Tests.MO
 
     public class TaxTable2017Tests
     {
-        [Test]
-        //official documentation was off, but matched it up until the final addition
-        [TestCase(PayrollFrequency.Annually, -1, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
+        [Test]                
+        //official documentation was off, but matched it up until the final addition        
         [TestCase(PayrollFrequency.Annually, 0, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
         [TestCase(PayrollFrequency.Annually, 1, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
         [TestCase(PayrollFrequency.Annually, 30000, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 855)]
@@ -24,6 +23,16 @@ namespace CertiPay.Taxes.State.Tests.MO
             var result = table.Calculate(grossWages, frequency, filingStatus, federalWithholding, allowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        [TestCase(PayrollFrequency.Annually, -1, FilingStatus.MarriedWithTwoIncomes, 2270, 2)]
+        public void Missouri_2017_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus filingStatus, decimal federalWithholding, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.MO, year: 2017) as Missouri.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, filingStatus, federalWithholding, allowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/MO/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MO/TaxTable2017Tests.cs
@@ -10,6 +10,9 @@ namespace CertiPay.Taxes.State.Tests.MO
     {
         [Test]
         //official documentation was off, but matched it up until the final addition
+        [TestCase(PayrollFrequency.Annually, -1, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
+        [TestCase(PayrollFrequency.Annually, 0, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
+        [TestCase(PayrollFrequency.Annually, 1, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 0)]
         [TestCase(PayrollFrequency.Annually, 30000, FilingStatus.MarriedWithTwoIncomes, 2270, 2, 855)]
         //pcc
         [TestCase(PayrollFrequency.Annually, 9001, FilingStatus.Single, 670.10, 5, 0)]

--- a/CertiPay.Taxes.State.Tests/MS/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MS/TaxTable2017Tests.cs
@@ -9,6 +9,9 @@ namespace CertiPay.Taxes.State.Tests.MS
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
+        [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
+        [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 28.00)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.HeadOfFamily, 9500, 19)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.Married, 12000, 13)]

--- a/CertiPay.Taxes.State.Tests/MS/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/MS/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.MS
 {
@@ -8,8 +9,7 @@ namespace CertiPay.Taxes.State.Tests.MS
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
+        [Test]        
         [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
         [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 28.00)]
@@ -23,5 +23,20 @@ namespace CertiPay.Taxes.State.Tests.MS
 
             Assert.AreEqual(expected, result);
         }
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Single, 6000, 0.00)]
+        public void NegativeValue_Mississippi_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances, decimal expected)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.MS, year: 2017) as Mississippi.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
+        }
+
+
+
+
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/MT/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/MT/TaxTableTests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.MT
     public class TaxTableTests
     {
         [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, 5, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 0, 5, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 1, 5, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 550, 5, 3d)]
         [TestCase(PayrollFrequency.BiWeekly, 2950, 2, 152d)]
         [TestCase(PayrollFrequency.Weekly, 135, 1, 2d)]

--- a/CertiPay.Taxes.State.Tests/MT/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/MT/TaxTableTests.cs
@@ -6,8 +6,7 @@ namespace CertiPay.Taxes.State.Tests.MT
 {
     public class TaxTableTests
     {
-        [Test]
-        [TestCase(PayrollFrequency.SemiMonthly, -1, 5, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.SemiMonthly, 0, 5, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1, 5, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 550, 5, 3d)]
@@ -21,5 +20,15 @@ namespace CertiPay.Taxes.State.Tests.MT
 
             Assert.AreEqual(expected, result);
         }
+
+        [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, 5)]
+        public void NegativeValues_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.MT, year: 2017) as Montana.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, allowances));
+        }
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/NC/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NC/TaxTable2016Tests.cs
@@ -9,6 +9,9 @@ namespace CertiPay.Taxes.State.Tests.NC
     public class TaxTable2016Tests
     {
         [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 2, 0)]
+        [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 2, 0)]
+        [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 2, 0)]
         [TestCase(PayrollFrequency.Weekly, 450, FilingStatus.Single, 2, 12)]
         [TestCase(PayrollFrequency.BiWeekly, 1000, FilingStatus.Single, 1, 35)]
         [TestCase(PayrollFrequency.SemiMonthly, 1000, EmployeeTaxFilingStatus.Single, 1, 34)]

--- a/CertiPay.Taxes.State.Tests/NC/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NC/TaxTable2016Tests.cs
@@ -8,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.NC
 
     public class TaxTable2016Tests
     {
-        [Test]
-        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 2, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.Weekly, 0, FilingStatus.Single, 2, 0)]
         [TestCase(PayrollFrequency.Weekly, 1, FilingStatus.Single, 2, 0)]
         [TestCase(PayrollFrequency.Weekly, 450, FilingStatus.Single, 2, 12)]
@@ -28,6 +27,15 @@ namespace CertiPay.Taxes.State.Tests.NC
             var result = table.Calculate(grossWages, frequency, taxStatus, allowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, FilingStatus.Single, 2)]
+        public void NegativeValues_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus taxStatus, int allowances)
+        {
+            var table = TaxTables.GetForState<NorthCarolina.TaxTable>(StateOrProvince.NC, year: 2016);
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, taxStatus, allowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/ND/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ND/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.ND
     {
         [Test]
         //Documentation example
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
         [TestCase(600, PayrollFrequency.Weekly, FilingStatus.Single, 2, 4.00)]
         //PCC
         [TestCase(3000, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 25.00)]

--- a/CertiPay.Taxes.State.Tests/ND/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/ND/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.ND
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.ND
     public class TaxTable2017Tests
     {
         [Test]
-        //Documentation example
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
+        //Documentation example        
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 2, 0)]
         [TestCase(600, PayrollFrequency.Weekly, FilingStatus.Single, 2, 4.00)]
@@ -23,6 +23,16 @@ namespace CertiPay.Taxes.State.Tests.ND
             var result = table.Calculate(grossWages, freq, filingStatus, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]        
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 2)]
+        public void NorthDakota_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.ND, year: 2017) as NorthDakota.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/NE/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NE/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.NE
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.NE
     public class TaxTable2017Tests
     {
         [Test]
-        //Verified with PCC
-        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
+        //Verified with PCC        
         [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
         [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 249.80)]
@@ -21,6 +21,15 @@ namespace CertiPay.Taxes.State.Tests.NE
             var result = table.Calculate(grossWages, freq, filingStatus, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]        
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 1)]
+        public void NegativeValues_Nebraska_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.NE, year: 2017) as Nebraska.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/NE/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NE/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.NE
     {
         [Test]
         //Verified with PCC
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
+        [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
+        [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 0)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Married, 1, 249.80)]
         [TestCase(4600, PayrollFrequency.BiWeekly, FilingStatus.Single, 0, 277.32)]
         [TestCase(5, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]

--- a/CertiPay.Taxes.State.Tests/NJ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NJ/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.NJ
 {
@@ -18,8 +19,7 @@ namespace CertiPay.Taxes.State.Tests.NJ
             Assert.AreEqual(10.00m, result);
         }
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Single, 1, 21.25)]
@@ -34,6 +34,15 @@ namespace CertiPay.Taxes.State.Tests.NJ
             var result = table.Calculate(grossWages, freq, status, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1)]
+        public void Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus status, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.NJ, year: 2017) as NewJersey.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, status, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/NJ/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NJ/TaxTable2017Tests.cs
@@ -19,6 +19,9 @@ namespace CertiPay.Taxes.State.Tests.NJ
         }
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.Single, 1, 21.25)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.MarriedWithTwoIncomes, 1, 21.25)]
         [TestCase(1500, PayrollFrequency.Monthly, FilingStatus.MarriedFilingSeparate, 1, 21.25)]

--- a/CertiPay.Taxes.State.Tests/NM/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NM/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.NM
     {
         [Test]
         //Verified with PCC
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
+        [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
+        [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
         [TestCase(2205, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 60.79)]
         [TestCase(2205, PayrollFrequency.BiWeekly, FilingStatus.Single, 0, 92.96)]
         [TestCase(5, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]

--- a/CertiPay.Taxes.State.Tests/NM/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NM/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.NM
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.NM
     public class TaxTable2017Tests
     {
         [Test]
-        //Verified with PCC
-        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
+        //Verified with PCC        
         [TestCase(0, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
         [TestCase(1, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 0)]
         [TestCase(2205, PayrollFrequency.BiWeekly, FilingStatus.Married, 2, 60.79)]
@@ -21,6 +21,15 @@ namespace CertiPay.Taxes.State.Tests.NM
             var result = table.Calculate(grossWages, freq, filingStatus, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]        
+        [TestCase(-1, PayrollFrequency.BiWeekly, FilingStatus.Married, 2)]
+        public void NewMexico_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.NM, year: 2017) as NewMexico.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/NY/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NY/TaxTable2017Tests.cs
@@ -1,6 +1,7 @@
 ﻿using CertiPay.Payroll.Common;
 using CertiPay.Taxes.State.NewYork;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.NY
 {
@@ -9,8 +10,7 @@ namespace CertiPay.Taxes.State.Tests.NY
     {
         private NewYork.TaxTable2017 ny2017 = new NewYork.TaxTable2017();
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 32.46)]
@@ -26,6 +26,15 @@ namespace CertiPay.Taxes.State.Tests.NY
             var result = table.Calculate(grossWages, freq, region, status, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1)]
+        public void NegativeValues_NewYorkTaxTable2017(decimal grossWages, PayrollFrequency freq, Region region, FilingStatus status, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.NY, year: 2017) as NewYork.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, region, status, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/NY/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/NY/TaxTable2017Tests.cs
@@ -10,6 +10,9 @@ namespace CertiPay.Taxes.State.Tests.NY
         private NewYork.TaxTable2017 ny2017 = new NewYork.TaxTable2017();
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Single, 1, 32.46)]
         [TestCase(1500, PayrollFrequency.Monthly, Region.NewYorkState, FilingStatus.Married, 1, 30.40)]
         [TestCase(1500, PayrollFrequency.Monthly, Region.Yonkers, FilingStatus.Single, 1, 32.46)]

--- a/CertiPay.Taxes.State.Tests/OH/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/OH/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.OH
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.OH
     public class TaxTable2017Tests
     {        
 
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 21.66)]
@@ -22,6 +22,15 @@ namespace CertiPay.Taxes.State.Tests.OH
             var result = table.Calculate(grossWages, freq, exemptions);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1)]
+        public void NegativeValues_Ohio_2017_TaxTable(decimal grossWages, PayrollFrequency freq, int exemptions)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.OH, year: 2017) as Ohio.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, exemptions));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/OH/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/OH/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.OH
     {        
 
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 21.66)]
         [TestCase(1500, PayrollFrequency.Monthly, 3, 18.65)]
         [TestCase(80000, PayrollFrequency.Monthly, 5, 4256.87)]

--- a/CertiPay.Taxes.State.Tests/OK/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/OK/TaxTableTests.cs
@@ -17,8 +17,7 @@ namespace CertiPay.Taxes.State.Tests.OK
             Assert.AreEqual(expected, result);
         }
 
-        [Test]
-        [TestCase(PayrollFrequency.SemiMonthly, -1, true, 2, 0)]
+        [Test]        
         [TestCase(PayrollFrequency.SemiMonthly, 0, true, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1, true, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1825, true, 2, 46d)]
@@ -31,5 +30,16 @@ namespace CertiPay.Taxes.State.Tests.OK
 
             Assert.AreEqual(expected, result);
         }
+
+
+        [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, true, 2)]
+        public void NegativeValues_Checks_And_Balances_2017(PayrollFrequency frequency, Decimal grossWages, Boolean isMarried, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.OK, year: 2017) as Oklahoma.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, isMarried, allowances));
+        }
+        
     }
 }

--- a/CertiPay.Taxes.State.Tests/OK/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/OK/TaxTableTests.cs
@@ -18,6 +18,9 @@ namespace CertiPay.Taxes.State.Tests.OK
         }
 
         [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, true, 2, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 0, true, 2, 0)]
+        [TestCase(PayrollFrequency.SemiMonthly, 1, true, 2, 0)]
         [TestCase(PayrollFrequency.SemiMonthly, 1825, true, 2, 46d)]
         [TestCase(PayrollFrequency.BiWeekly, 2500, true, 2, 83d)]
         public void Checks_And_Balances_2017(PayrollFrequency frequency, Decimal grossWages, Boolean isMarried, int allowances, Decimal expected)

--- a/CertiPay.Taxes.State.Tests/OR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/OR/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.OR
     {
         [Test]
         //Verified with Example
+        [TestCase(-1, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
+        [TestCase(0, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
+        [TestCase(1, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
         [TestCase(15000, PayrollFrequency.Annually, 1440, FilingStatus.Single,  0, 984)]
         //Verified with PCC
         [TestCase(132000, PayrollFrequency.Annually, 22315.0, FilingStatus.Married,  3, 9832.00)]

--- a/CertiPay.Taxes.State.Tests/OR/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/OR/TaxTable2017Tests.cs
@@ -1,5 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.OR
 {
@@ -7,8 +8,7 @@ namespace CertiPay.Taxes.State.Tests.OR
     public class TaxTable2017Tests
     {
         [Test]
-        //Verified with Example
-        [TestCase(-1, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
+        //Verified with Example        
         [TestCase(0, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
         [TestCase(1, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0, 0)]
         [TestCase(15000, PayrollFrequency.Annually, 1440, FilingStatus.Single,  0, 984)]
@@ -22,6 +22,17 @@ namespace CertiPay.Taxes.State.Tests.OR
             var result = table.Calculate(grossWages, freq, federalWithholding, filingStatus, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]        
+        [TestCase(-1, PayrollFrequency.Annually, 1440, FilingStatus.Single, 0)]
+        public void NegativeValue_Oregon_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, decimal federalWithholding, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.OR, year: 2017) as Oregon.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, federalWithholding, filingStatus, personalAllowances));
+
+            
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/RI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/RI/TaxTable2017Tests.cs
@@ -1,13 +1,13 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.RI
 {
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [Test]        
         [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 53.12)]
@@ -19,6 +19,15 @@ namespace CertiPay.Taxes.State.Tests.RI
             var result = table.Calculate(grossWages, freq, personalAllowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1)]
+        public void NegativeValues_RI2017Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.RI, year: 2017) as RhodeIsland.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, personalAllowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/RI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/RI/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.RI
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(0, PayrollFrequency.Monthly, 1, 0)]
+        [TestCase(1, PayrollFrequency.Monthly, 1, 0)]
         [TestCase(1500, PayrollFrequency.Monthly, 1, 53.12)]
         [TestCase(18112.51, PayrollFrequency.Monthly, 1, 889.81)]
         public void RI2017Checks_And_Balances(decimal grossWages, PayrollFrequency freq, int personalAllowances, decimal expected)

--- a/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
@@ -9,7 +9,7 @@ namespace CertiPay.Taxes.State.Tests.SC
         [Test]
         [TestCase(-1, 0, PayrollFrequency.Monthly, 0)]
         [TestCase(0, 0, PayrollFrequency.Monthly, 0)]
-        [TestCase(1, 0, PayrollFrequency.Monthly, 0)]
+        [TestCase(1, 0, PayrollFrequency.Monthly, 0.02)]
         [TestCase(3000, 0, PayrollFrequency.Monthly, 182.72)]
         [TestCase(2500, 0, PayrollFrequency.Monthly, 147.72)]
         [TestCase(3000, 1, PayrollFrequency.Monthly, 152.21)]
@@ -30,6 +30,16 @@ namespace CertiPay.Taxes.State.Tests.SC
             var result = table.Calculate(grossWages, payrollFrequency, exemptions);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        [TestCase(-1, 0, PayrollFrequency.Monthly)]
+        public void NegativeValues_Checks_And_Balances(Decimal grossWages, int exemptions, PayrollFrequency payrollFrequency)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.SC, year: 2017) as SouthCarolina.TaxTable;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, payrollFrequency, exemptions));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
@@ -6,8 +6,7 @@ namespace CertiPay.Taxes.State.Tests.SC
 {
     public class TaxTable2017Tests
     {
-        [Test]
-        [TestCase(-1, 0, PayrollFrequency.Monthly, 0)]
+        [Test]        
         [TestCase(0, 0, PayrollFrequency.Monthly, 0)]
         [TestCase(1, 0, PayrollFrequency.Monthly, 0.02)]
         [TestCase(3000, 0, PayrollFrequency.Monthly, 182.72)]

--- a/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/SC/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.SC
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, 0, PayrollFrequency.Monthly, 0)]
+        [TestCase(0, 0, PayrollFrequency.Monthly, 0)]
+        [TestCase(1, 0, PayrollFrequency.Monthly, 0)]
         [TestCase(3000, 0, PayrollFrequency.Monthly, 182.72)]
         [TestCase(2500, 0, PayrollFrequency.Monthly, 147.72)]
         [TestCase(3000, 1, PayrollFrequency.Monthly, 152.21)]

--- a/CertiPay.Taxes.State.Tests/UT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/UT/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.UT
     {
         [Test]
         //verified with PCC
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(400, PayrollFrequency.Weekly, FilingStatus.Single, 1, 14.99)]
         [TestCase(2500, PayrollFrequency.Monthly, FilingStatus.Married, 3, 75.5)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.Single, 2, 37.77)]

--- a/CertiPay.Taxes.State.Tests/UT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/UT/TaxTable2017Tests.cs
@@ -8,7 +8,7 @@ namespace CertiPay.Taxes.State.Tests.UT
     {
         [Test]
         //verified with PCC
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
+        
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(400, PayrollFrequency.Weekly, FilingStatus.Single, 1, 14.99)]
@@ -23,5 +23,19 @@ namespace CertiPay.Taxes.State.Tests.UT
 
             Assert.AreEqual(expected, result);
         }
+
+
+
+        [Test]
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1)]
+        public void NegativeValue_Utah_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.UT, year: 2017) as Utah.TaxTable;
+
+            Assert.Throws<System.ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
+        }
+
+        
     }
 }
+

--- a/CertiPay.Taxes.State.Tests/VA/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/VA/TaxTable2016Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.VA
     public class TaxTable2016Tests
     {
         [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, 2, 0d)]
+        [TestCase(PayrollFrequency.Weekly, 0, 2, 0d)]
+        [TestCase(PayrollFrequency.Weekly, 1, 2, 0d)]
         [TestCase(PayrollFrequency.Weekly, 450, 2, 15.55d)]
         [TestCase(PayrollFrequency.BiWeekly, 1000, 1, 38.90d)]
         [TestCase(PayrollFrequency.SemiMonthly, 1000, 2, 35.13d)]

--- a/CertiPay.Taxes.State.Tests/VA/TaxTable2016Tests.cs
+++ b/CertiPay.Taxes.State.Tests/VA/TaxTable2016Tests.cs
@@ -6,8 +6,7 @@ namespace CertiPay.Taxes.State.Tests.VA
 {
     public class TaxTable2016Tests
     {
-        [Test]
-        [TestCase(PayrollFrequency.Weekly, -1, 2, 0d)]
+        [Test]        
         [TestCase(PayrollFrequency.Weekly, 0, 2, 0d)]
         [TestCase(PayrollFrequency.Weekly, 1, 2, 0d)]
         [TestCase(PayrollFrequency.Weekly, 450, 2, 15.55d)]
@@ -20,6 +19,15 @@ namespace CertiPay.Taxes.State.Tests.VA
             var result = table.Calculate(grossWages, frequency, allowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+        [Test]
+        [TestCase(PayrollFrequency.Weekly, -1, 2)]
+        public void NegativeValues_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.VA, year: 2016) as Virginia.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, allowances));
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/VT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/VT/TaxTable2017Tests.cs
@@ -7,7 +7,7 @@ namespace CertiPay.Taxes.State.Tests.VT
     public class TaxTable2017Tests
     {
         [Test]
-        [TestCase(-1, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
+        
         [TestCase(0, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
         [TestCase(1, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
         [TestCase(3000, 1, FilingStatus.Married, PayrollFrequency.Monthly, 70.85)]
@@ -19,6 +19,18 @@ namespace CertiPay.Taxes.State.Tests.VT
             var result = table.Calculate(grossWages, payrollFrequency, filingStatus, exemptions);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+
+        [Test]
+        [TestCase(-1, 1, FilingStatus.Single, PayrollFrequency.Monthly)]
+        public void NegativeValues_VT_2017_Checks_And_Balances(Decimal grossWages, int exemptions, FilingStatus filingStatus, PayrollFrequency payrollFrequency)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.WI, year: 2017) as Wisconsin.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, payrollFrequency, filingStatus, exemptions));
+
         }
     }
 }

--- a/CertiPay.Taxes.State.Tests/VT/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/VT/TaxTable2017Tests.cs
@@ -7,6 +7,9 @@ namespace CertiPay.Taxes.State.Tests.VT
     public class TaxTable2017Tests
     {
         [Test]
+        [TestCase(-1, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
+        [TestCase(0, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
+        [TestCase(1, 1, FilingStatus.Single, PayrollFrequency.Monthly, 0)]
         [TestCase(3000, 1, FilingStatus.Married, PayrollFrequency.Monthly, 70.85)]
         [TestCase(2500, 1, FilingStatus.Single, PayrollFrequency.Monthly, 68.93)]
         public void VT_2017_Checks_And_Balances(Decimal grossWages, int exemptions, FilingStatus filingStatus, PayrollFrequency payrollFrequency, Decimal expected)

--- a/CertiPay.Taxes.State.Tests/WI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/WI/TaxTable2017Tests.cs
@@ -1,14 +1,13 @@
 ﻿using CertiPay.Payroll.Common;
 using NUnit.Framework;
+using System;
 
 namespace CertiPay.Taxes.State.Tests.WI
 {
     [TestFixture]
     public class TaxTable2017Tests
     {
-        [Test]
         //Verified with PCC
-        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(300, PayrollFrequency.Weekly, FilingStatus.Single, 1, 7.32)]
@@ -19,8 +18,19 @@ namespace CertiPay.Taxes.State.Tests.WI
             var table = TaxTables.GetForState(StateOrProvince.WI, year: 2017) as Wisconsin.TaxTable2017;
 
             var result = table.Calculate(grossWages, freq, filingStatus, personalAllowances);
-
+                           
             Assert.AreEqual(expected, result);
         }
+
+        [Test]        
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1)]
+        public void NegativeValue_Wisconsin_2017_Checks_And_Balances(decimal grossWages, PayrollFrequency freq, FilingStatus filingStatus, int personalAllowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.WI, year: 2017) as Wisconsin.TaxTable2017;
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, freq, filingStatus, personalAllowances));
+
+        }
+
     }
 }

--- a/CertiPay.Taxes.State.Tests/WI/TaxTable2017Tests.cs
+++ b/CertiPay.Taxes.State.Tests/WI/TaxTable2017Tests.cs
@@ -8,6 +8,9 @@ namespace CertiPay.Taxes.State.Tests.WI
     {
         [Test]
         //Verified with PCC
+        [TestCase(-1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
+        [TestCase(0, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
+        [TestCase(1, PayrollFrequency.Weekly, FilingStatus.Single, 1, 0)]
         [TestCase(300, PayrollFrequency.Weekly, FilingStatus.Single, 1, 7.32)]
         [TestCase(500, PayrollFrequency.Weekly, FilingStatus.Single, 3, 19.01)]
         [TestCase(1000, PayrollFrequency.BiWeekly, FilingStatus.Married, 3, 32.37)]

--- a/CertiPay.Taxes.State.Tests/WV/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/WV/TaxTableTests.cs
@@ -9,6 +9,9 @@ namespace CertiPay.Taxes.State.Tests.WV
     public class TaxTableTests
     {
         [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, FilingStatus.Two_Earnings, 2, 44d)]
+        [TestCase(PayrollFrequency.SemiMonthly, 0, FilingStatus.Two_Earnings, 2, 44d)]
+        [TestCase(PayrollFrequency.SemiMonthly, 1, FilingStatus.Two_Earnings, 2, 44d)]
         [TestCase(PayrollFrequency.SemiMonthly, 1250, FilingStatus.Two_Earnings, 2, 44d)]
         public void Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus status, int allowances, Decimal expected)
         {

--- a/CertiPay.Taxes.State.Tests/WV/TaxTableTests.cs
+++ b/CertiPay.Taxes.State.Tests/WV/TaxTableTests.cs
@@ -8,10 +8,9 @@ namespace CertiPay.Taxes.State.Tests.WV
 
     public class TaxTableTests
     {
-        [Test]
-        [TestCase(PayrollFrequency.SemiMonthly, -1, FilingStatus.Two_Earnings, 2, 44d)]
-        [TestCase(PayrollFrequency.SemiMonthly, 0, FilingStatus.Two_Earnings, 2, 44d)]
-        [TestCase(PayrollFrequency.SemiMonthly, 1, FilingStatus.Two_Earnings, 2, 44d)]
+        [Test]        
+        [TestCase(PayrollFrequency.SemiMonthly, 0, FilingStatus.Two_Earnings, 2, 0d)]
+        [TestCase(PayrollFrequency.SemiMonthly, 1, FilingStatus.Two_Earnings, 2, 0d)]
         [TestCase(PayrollFrequency.SemiMonthly, 1250, FilingStatus.Two_Earnings, 2, 44d)]
         public void Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus status, int allowances, Decimal expected)
         {
@@ -20,6 +19,16 @@ namespace CertiPay.Taxes.State.Tests.WV
             var result = table.Calculate(grossWages, frequency, status, allowances);
 
             Assert.AreEqual(expected, result);
+        }
+
+
+        [Test]
+        [TestCase(PayrollFrequency.SemiMonthly, -1, FilingStatus.Two_Earnings, 2)]
+        public void NegativeValues_Checks_And_Balances(PayrollFrequency frequency, Decimal grossWages, FilingStatus status, int allowances)
+        {
+            var table = TaxTables.GetForState(StateOrProvince.WV, year: 2017) as WestVirginia.TaxTable;            
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => table.Calculate(grossWages, frequency, status, allowances));
         }
     }
 }

--- a/CertiPay.Taxes.State/Alabama/TaxTable.cs
+++ b/CertiPay.Taxes.State/Alabama/TaxTable.cs
@@ -18,9 +18,22 @@ namespace CertiPay.Taxes.State.Alabama
 
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+
+        /// <summary>
+        /// Returns State Withholding for Alabama, when provided with a non-negative value for Gross Wages, Federal Withholding and Dependent Allowances. 
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="federalWithholding"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="dependentAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, decimal federalWithholding, FilingStatus filingStatus = FilingStatus.Single, int dependentAllowances = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (federalWithholding < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(federalWithholding)} cannot be a negative number");
+            if (dependentAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependentAllowances)} cannot be a negative number");
 
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 

--- a/CertiPay.Taxes.State/Alabama/TaxTable.cs
+++ b/CertiPay.Taxes.State/Alabama/TaxTable.cs
@@ -33,8 +33,8 @@ namespace CertiPay.Taxes.State.Alabama
             taxableWages -= GetDependentAllowance(annualWages, dependentAllowances);
 
             var taxWithheld = GetTaxWithholding(filingStatus, taxableWages);
-        
-            return frequency.CalculateDeannualized(taxWithheld);
+
+            return Math.Max(Decimal.Zero, frequency.CalculateDeannualized(taxWithheld));
         }
 
         internal virtual Decimal GetStandardDeduction(FilingStatus filingStatus, decimal grossWages)

--- a/CertiPay.Taxes.State/Alabama/TaxTable.cs
+++ b/CertiPay.Taxes.State/Alabama/TaxTable.cs
@@ -20,6 +20,8 @@ namespace CertiPay.Taxes.State.Alabama
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, decimal federalWithholding, FilingStatus filingStatus = FilingStatus.Single, int dependentAllowances = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             var annualWages = taxableWages;

--- a/CertiPay.Taxes.State/Arizona/TaxTable.cs
+++ b/CertiPay.Taxes.State/Arizona/TaxTable.cs
@@ -23,6 +23,13 @@ namespace CertiPay.Taxes.State.Arizona
             }
         }
 
+        /// <summary>
+        /// Returns the state withholding amount for Arizona when given a non-negative gross wage.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="taxRate"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, TaxRate taxRate = TaxRate.TwoPointSevenPercent)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Arizona/TaxTable.cs
+++ b/CertiPay.Taxes.State/Arizona/TaxTable.cs
@@ -25,7 +25,10 @@ namespace CertiPay.Taxes.State.Arizona
 
         public virtual Decimal Calculate(Decimal grossWages, TaxRate taxRate = TaxRate.TwoPointSevenPercent)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             return grossWages * GetTaxRate(taxRate);
+            
         }
 
         internal decimal GetTaxRate(TaxRate taxRate)

--- a/CertiPay.Taxes.State/Arkansas/TaxTable.cs
+++ b/CertiPay.Taxes.State/Arkansas/TaxTable.cs
@@ -44,7 +44,7 @@ namespace CertiPay.Taxes.State.Arkansas
             taxableWages = (withholdingTable.Percentage * taxableWages) - withholdingTable.FlatAmount;
             taxableWages -= getExemptions(taxableWages, exemptions);
 
-            return frequency.CalculateDeannualized(taxableWages);
+            return Math.Max(Decimal.Zero, frequency.CalculateDeannualized(taxableWages));
         }
 
         private Bracket getBracket(decimal taxableWages)
@@ -76,7 +76,8 @@ namespace CertiPay.Taxes.State.Arkansas
             {
                 return new[]
                 {
-                    new Bracket {  Floor = 0, Ceiling = 4300, FlatAmount = 0.00m, Percentage = 0.09m },
+                    new Bracket { Floor = Decimal.MinValue, Percentage = Decimal.Zero },
+                    new Bracket { Floor = 0, Ceiling = 4300, FlatAmount = 0.00m, Percentage = 0.09m },
                     new Bracket { Floor = 4300, Ceiling = 8400, FlatAmount = 64.49m, Percentage = 0.024m },
                     new Bracket { Floor = 8400, Ceiling = 12600, FlatAmount = 148.48m, Percentage = 0.034m },
                     new Bracket { Floor = 12600, Ceiling = 21000, FlatAmount = 274.47m, Percentage = 0.044m },

--- a/CertiPay.Taxes.State/Arkansas/TaxTable.cs
+++ b/CertiPay.Taxes.State/Arkansas/TaxTable.cs
@@ -34,6 +34,8 @@ namespace CertiPay.Taxes.State.Arkansas
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
             taxableWages -= StandardDeductionValue;
             if (taxableWages < roundingValue)

--- a/CertiPay.Taxes.State/Colorado/TaxTable.cs
+++ b/CertiPay.Taxes.State/Colorado/TaxTable.cs
@@ -12,10 +12,28 @@ namespace CertiPay.Taxes.State.Colorado
         protected abstract Decimal Allowance { get; }
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Colorado State Withholding when given a non-negative value for Gross Wages and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int personalAllowances)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+            if (taxableWages <= 0)
+            {
+                return 0;
+            }
+
             var taxRate = GetTaxWithholding(filingStatus, taxableWages);
             var taxWithheld = taxRate.TaxBase + ((taxableWages - taxRate.StartingAmount) * taxRate.TaxRate);
 

--- a/CertiPay.Taxes.State/Connecticut/TaxTable.cs
+++ b/CertiPay.Taxes.State/Connecticut/TaxTable.cs
@@ -15,10 +15,20 @@ namespace CertiPay.Taxes.State.Connecticut
         public abstract IEnumerable<TaxRecapture> TaxRecaptureRates { get; }
         public abstract IEnumerable<ExemptionValue> ExemptionValues { get; }
 
+        /// <summary>
+        /// Returns Connecticut State Withholding when provided with a non-negative value for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="employeeCode"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, WithholdingCode employeeCode, int exemptions = 1)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
-
+            if (exemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(exemptions)} cannot be a negative number");
+            
             // Additional/Reduced Withholding handled outside of this calculation
 
             if (employeeCode == WithholdingCode.E)
@@ -38,16 +48,12 @@ namespace CertiPay.Taxes.State.Connecticut
                 taxableWages += GetTaxRecapture(employeeCode, annualizedSalary);
                 var taxWithheld = taxableWages * (1 - GetPersonalTaxCredits(employeeCode, annualizedSalary));
 
-                taxWithheld = frequency.CalculateDeannualized(taxWithheld);
-                //taxWithheld += additionalWithholding;
-                //taxWithheld -= reducedWithholding;
+                taxWithheld = frequency.CalculateDeannualized(taxWithheld);                
                 return Math.Max(taxWithheld, 0);
             }
             else
-            {
-                //taxableWages += additionalWithholding;
-                //taxableWages -= reducedWithholding;
-                return Math.Max(taxableWages, 0);
+            {                
+                return 0;
             }
         }
 

--- a/CertiPay.Taxes.State/Connecticut/TaxTable.cs
+++ b/CertiPay.Taxes.State/Connecticut/TaxTable.cs
@@ -17,6 +17,8 @@ namespace CertiPay.Taxes.State.Connecticut
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, WithholdingCode employeeCode, int exemptions = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             // Additional/Reduced Withholding handled outside of this calculation
 
             if (employeeCode == WithholdingCode.E)

--- a/CertiPay.Taxes.State/Delaware/TaxTable.cs
+++ b/CertiPay.Taxes.State/Delaware/TaxTable.cs
@@ -27,9 +27,15 @@ namespace CertiPay.Taxes.State.Delaware
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
+
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);                        
 
-            taxableWages -= GetStandardDeduction(filingStatus);            
+            taxableWages -= GetStandardDeduction(filingStatus);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(taxableWages);            
 

--- a/CertiPay.Taxes.State/Delaware/TaxTable.cs
+++ b/CertiPay.Taxes.State/Delaware/TaxTable.cs
@@ -23,13 +23,22 @@ namespace CertiPay.Taxes.State.Delaware
 
                 throw new NotImplementedException($"SUI Wage Base is not configured for Delaware for {Year}");
             }
-        }    
+        }
 
+        /// <summary>
+        /// Returns Delaware State Withholding when given a non-negative value for Gross Wages and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
-
-            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
-
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);                        
 
             taxableWages -= GetStandardDeduction(filingStatus);

--- a/CertiPay.Taxes.State/Hawaii/TaxTable.cs
+++ b/CertiPay.Taxes.State/Hawaii/TaxTable.cs
@@ -15,9 +15,14 @@ namespace CertiPay.Taxes.State.Hawaii
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int allowances = 0, FilingStatus filingStatus = FilingStatus.Single)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetAllowances(allowances);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = getTaxRateRow(taxableWages, filingStatus);
 

--- a/CertiPay.Taxes.State/Hawaii/TaxTable.cs
+++ b/CertiPay.Taxes.State/Hawaii/TaxTable.cs
@@ -11,12 +11,22 @@ namespace CertiPay.Taxes.State.Hawaii
 
         protected abstract decimal Allowance { get; }
 
-        protected abstract IEnumerable<TaxRate> TaxRates { get; }      
+        protected abstract IEnumerable<TaxRate> TaxRates { get; }
 
+        /// <summary>
+        /// Returns Hawaii State Withholding when provided with a non-negative value for Gross Wages and Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="allowances"></param>
+        /// <param name="filingStatus"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int allowances = 0, FilingStatus filingStatus = FilingStatus.Single)
         {
-            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
-
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (allowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(allowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetAllowances(allowances);

--- a/CertiPay.Taxes.State/Idaho/TaxTable.cs
+++ b/CertiPay.Taxes.State/Idaho/TaxTable.cs
@@ -14,11 +14,26 @@ namespace CertiPay.Taxes.State.Idaho
 
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Idaho State Withholding when given a non-negative value for gross wages and personal allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 

--- a/CertiPay.Taxes.State/Illinois/TaxTable.cs
+++ b/CertiPay.Taxes.State/Illinois/TaxTable.cs
@@ -37,7 +37,7 @@ namespace CertiPay.Taxes.State.Illinois
 
             var annualized_taxes = annualized_wages * 0.0375m;
 
-            return frequency.CalculateDeannualized(annualized_taxes);
+            return Math.Max(0, frequency.CalculateDeannualized(annualized_taxes));
         }
     }
 }

--- a/CertiPay.Taxes.State/Illinois/TaxTable.cs
+++ b/CertiPay.Taxes.State/Illinois/TaxTable.cs
@@ -7,8 +7,22 @@ namespace CertiPay.Taxes.State.Illinois
     {
         public override StateOrProvince State { get { return StateOrProvince.IL; } }
 
+
+        /// <summary>
+        /// Returns Illinois State Withholding when provided with a non-negative value for Gross Wages, basic allowances and aditional allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="basicAllowances"></param>
+        /// <param name="additionalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int basicAllowances = 0, int additionalAllowances = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (additionalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(additionalAllowances)} cannot be a negative number");
+            if (basicAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(basicAllowances)} cannot be a negative number");
+
             var annualized_wages = frequency.CalculateAnnualized(grossWages);
 
             //Step 1 Determine the wages paid for the payroll period.

--- a/CertiPay.Taxes.State/Indiana/TaxTable.cs
+++ b/CertiPay.Taxes.State/Indiana/TaxTable.cs
@@ -13,8 +13,22 @@ namespace CertiPay.Taxes.State.Indiana
 
         public abstract Decimal StateTaxRate { get; }
 
+
+        /// <summary>
+        /// Returns Indiana State Withholding when a non-negative value is given for gross wages, personal allowances and dependent allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="personalAllowances"></param>
+        /// <param name="dependentAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int personalAllowances = 1, int dependentAllowances = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            if (dependentAllowances< Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependentAllowances)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);

--- a/CertiPay.Taxes.State/Indiana/TaxTable.cs
+++ b/CertiPay.Taxes.State/Indiana/TaxTable.cs
@@ -23,7 +23,7 @@ namespace CertiPay.Taxes.State.Indiana
 
             var taxWithheld = GetTaxWithholding(taxableWages);
 
-            return frequency.CalculateDeannualized(taxWithheld);
+            return Math.Max(0, frequency.CalculateDeannualized(taxWithheld));
         }
 
         internal virtual Decimal GetPersonalAllowance(int personalAllowances = 1)

--- a/CertiPay.Taxes.State/Iowa/TaxTable.cs
+++ b/CertiPay.Taxes.State/Iowa/TaxTable.cs
@@ -47,7 +47,7 @@ namespace CertiPay.Taxes.State.Iowa
 
             withheldWages -= GetAllowances(exemptions);
 
-            return frequency.CalculateDeannualized(withheldWages);
+            return Math.Max(0, frequency.CalculateDeannualized(withheldWages));
         }
 
         protected virtual Decimal GetStandardDeduction(int exemptions)

--- a/CertiPay.Taxes.State/Iowa/TaxTable.cs
+++ b/CertiPay.Taxes.State/Iowa/TaxTable.cs
@@ -31,6 +31,15 @@ namespace CertiPay.Taxes.State.Iowa
 
         protected virtual Decimal Allowance { get; } = 40;
 
+        /// <summary>
+        /// Returns the State Withholding for Iowa when provided with a non-negative value for Gross Wages, Exemptions and Federal Withholding.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="FedWithholding"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, Decimal FedWithholding = 0, int exemptions = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Kansas/TaxTable.cs
+++ b/CertiPay.Taxes.State/Kansas/TaxTable.cs
@@ -14,9 +14,20 @@ namespace CertiPay.Taxes.State.Kansas
 
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Kansas State Withholding when given a non-negative value for Gross Wages and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int personalAllowances = 1)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");                        
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);

--- a/CertiPay.Taxes.State/Kansas/TaxTable.cs
+++ b/CertiPay.Taxes.State/Kansas/TaxTable.cs
@@ -16,9 +16,14 @@ namespace CertiPay.Taxes.State.Kansas
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 

--- a/CertiPay.Taxes.State/Kentucky/TaxTable.cs
+++ b/CertiPay.Taxes.State/Kentucky/TaxTable.cs
@@ -15,6 +15,14 @@ namespace CertiPay.Taxes.State.Kentucky
 
         protected abstract IEnumerable<Bracket> Brackets { get; }
 
+        /// <summary>
+        /// Returns Kentucky State Withholding when given a non-negative value for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Kentucky/TaxTable.cs
+++ b/CertiPay.Taxes.State/Kentucky/TaxTable.cs
@@ -28,7 +28,7 @@ namespace CertiPay.Taxes.State.Kentucky
 
             withheldWages -= GetExemptions(exemptions);
 
-            return frequency.CalculateDeannualized(withheldWages);
+            return Math.Max(0, frequency.CalculateDeannualized(withheldWages));
         }
 
         protected virtual Decimal GetExemptions(int exemptions)

--- a/CertiPay.Taxes.State/Louisiana/TaxTable.cs
+++ b/CertiPay.Taxes.State/Louisiana/TaxTable.cs
@@ -15,11 +15,22 @@ namespace CertiPay.Taxes.State.Louisiana
 
         public virtual IEnumerable<Rate> Rates { get; }
 
+        /// <summary>
+        /// Returns Lousiana State Withholding when given a non-negative value for Gross Wages, Personal Exemptions, and Dependents.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalExemptions"></param>
+        /// <param name="dependents"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int personalExemptions = 0, int dependents = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
             if (personalExemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalExemptions)} cannot be a negative number");
-
+            if (dependents < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependents)} cannot be a negative number");
+            
             var TaxableWages = frequency.CalculateAnnualized(grossWages);
 
             var rate = GetRate(filingStatus, personalExemptions);

--- a/CertiPay.Taxes.State/Maine/TaxTable.cs
+++ b/CertiPay.Taxes.State/Maine/TaxTable.cs
@@ -15,9 +15,20 @@ namespace CertiPay.Taxes.State.Maine
 
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Maine State Withholding when given a non-negative value for Gross Wages and Withholding Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="withholdingAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int withholdingAllowances = 1)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (withholdingAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(withholdingAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             var annualWages = taxableWages;

--- a/CertiPay.Taxes.State/Maine/TaxTable.cs
+++ b/CertiPay.Taxes.State/Maine/TaxTable.cs
@@ -17,6 +17,7 @@ namespace CertiPay.Taxes.State.Maine
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int withholdingAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             var annualWages = taxableWages;

--- a/CertiPay.Taxes.State/Massachusettes/TaxTable.cs
+++ b/CertiPay.Taxes.State/Massachusettes/TaxTable.cs
@@ -27,6 +27,7 @@ namespace CertiPay.Taxes.State.Massachusettes
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, Decimal fica_withholding, int exemptions = 1, bool isBlind = false, bool isHeadOfHousehold = false)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
             // Note: This does not take into account other retirement systems i.e. US and Railroad Retirement Systems
 
             // We annualize the wages from this period
@@ -69,7 +70,7 @@ namespace CertiPay.Taxes.State.Massachusettes
 
             // Then, we deannualize the amount back to the period
 
-            return frequency.CalculateDeannualized(annualized_withholding);
+            return Math.Max(0, frequency.CalculateDeannualized(annualized_withholding));
         }
 
         internal virtual Decimal Get_Exemption_Value(int number_of_exemptions)

--- a/CertiPay.Taxes.State/Massachusettes/TaxTable.cs
+++ b/CertiPay.Taxes.State/Massachusettes/TaxTable.cs
@@ -25,9 +25,23 @@ namespace CertiPay.Taxes.State.Massachusettes
 
         internal virtual Decimal Exemption_Bonus { get; } = 3400;
 
+        /// <summary>
+        /// Returns Massachusettes State Withholding when provided with a non-negative value for Fica Withholding, Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="fica_withholding"></param>
+        /// <param name="exemptions"></param>
+        /// <param name="isBlind"></param>
+        /// <param name="isHeadOfHousehold"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, Decimal fica_withholding, int exemptions = 1, bool isBlind = false, bool isHeadOfHousehold = false)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (fica_withholding < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(fica_withholding)} cannot be a negative number");
+            if (exemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(exemptions)} cannot be a negative number");
+        
             // Note: This does not take into account other retirement systems i.e. US and Railroad Retirement Systems
 
             // We annualize the wages from this period

--- a/CertiPay.Taxes.State/Michigan/TaxTable.cs
+++ b/CertiPay.Taxes.State/Michigan/TaxTable.cs
@@ -11,10 +11,22 @@ namespace CertiPay.Taxes.State.Michigan
 
         public virtual Decimal Tax { get; }
 
+
+        /// <summary>
+        /// Returns Michigan State Withholding when given a non-negative value for Gross Wages, Personal Exemptions and Dependents.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="personalExemptions"></param>
+        /// <param name="dependents"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int personalExemptions = 0, int dependents = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
             if (personalExemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalExemptions)} cannot be a negative number");
+            if (dependents < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependents)} cannot be a negative number");
+            
 
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 

--- a/CertiPay.Taxes.State/Minnesota/TaxTable.cs
+++ b/CertiPay.Taxes.State/Minnesota/TaxTable.cs
@@ -20,6 +20,9 @@ namespace CertiPay.Taxes.State.Minnesota
 
             taxableWages -= GetAllowance(allowances);
 
+            if (taxableWages <= 0)
+                return 0;
+
             var selectedRow = GetTaxableWithholding(filingStatus, taxableWages);
 
             var taxWithheld = selectedRow.TaxBase + ((taxableWages - selectedRow.StartingAmount) * selectedRow.TaxRate);

--- a/CertiPay.Taxes.State/Minnesota/TaxTable.cs
+++ b/CertiPay.Taxes.State/Minnesota/TaxTable.cs
@@ -11,6 +11,15 @@ namespace CertiPay.Taxes.State.Minnesota
         public virtual Decimal Allowance { get; }
         public virtual IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Minnestoa State Withholding when given a non-negative value for Gross Wages and Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="allowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int allowances = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Mississippi/TaxTable.cs
+++ b/CertiPay.Taxes.State/Mississippi/TaxTable.cs
@@ -12,6 +12,15 @@ namespace CertiPay.Taxes.State.Mississippi
 
         protected virtual IEnumerable<StandardDeduction> StandardDeductions { get; }
 
+        /// <summary>
+        /// Returns Mississippi State Withholding when given a non-negative vlaue for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="exemption"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, decimal exemption)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Missouri/TaxTable.cs
+++ b/CertiPay.Taxes.State/Missouri/TaxTable.cs
@@ -16,8 +16,22 @@ namespace CertiPay.Taxes.State.Missouri
         protected abstract Decimal TaxAmount { get; }
         protected abstract Decimal TaxIncrement { get; }
 
+        /// <summary>
+        /// Returns Missouri Withholding when given a non-negative value for Gross Wages, Federal Withholding and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="federalWithholding"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, Decimal federalWithholding, int personalAllowances)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            if (federalWithholding < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(federalWithholding)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
             var fedWithholding = frequency.CalculateAnnualized(federalWithholding);
 

--- a/CertiPay.Taxes.State/Montana/TaxTable.cs
+++ b/CertiPay.Taxes.State/Montana/TaxTable.cs
@@ -47,7 +47,11 @@ namespace CertiPay.Taxes.State.Montana
 
             Decimal flat_amount = 0, bracket_floor = 0, percentage = 0m;
 
-            if (taxable_earnings < 7000)
+            if (taxable_earnings <= 0)
+            {
+                return 0;
+            }
+            else if (taxable_earnings < 7000)
             {
                 flat_amount = 0;
                 bracket_floor = 0;

--- a/CertiPay.Taxes.State/Montana/TaxTable.cs
+++ b/CertiPay.Taxes.State/Montana/TaxTable.cs
@@ -26,6 +26,14 @@ namespace CertiPay.Taxes.State.Montana
 
         public Decimal AllowanceValue { get; } = 1900;
 
+        /// <summary>
+        /// Returns Montana State Withholding when given a non-negative value for Gross Wages and Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="allowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int allowances = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Nebraska/TaxTable.cs
+++ b/CertiPay.Taxes.State/Nebraska/TaxTable.cs
@@ -13,8 +13,19 @@ namespace CertiPay.Taxes.State.Nebraska
         protected abstract decimal PersonalAllowances { get; }        
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Nebraska State Withholding when given a non-negative value for Gross Wages and Personal Allowances
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);    
 
             taxableWages -= GetPersonalAllowance(personalAllowances);                                    

--- a/CertiPay.Taxes.State/New Jersey/TaxTable.cs
+++ b/CertiPay.Taxes.State/New Jersey/TaxTable.cs
@@ -9,27 +9,26 @@ namespace CertiPay.Taxes.State.NewJersey
     public abstract class TaxTable : TaxTableHeader
     {
         public override StateOrProvince State { get { return StateOrProvince.NJ; } }
-        
+
         public abstract decimal PersonalAllowances { get; }
-        
+
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
             var taxableWages = frequency.CalculateAnnualized(grossWages);
-          
-            taxableWages -= GetPersonalAllowance(personalAllowances);            
+
+            taxableWages -= GetPersonalAllowance(personalAllowances);
 
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);
-            
+
             var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);
 
             return frequency.CalculateDeannualized(taxWithheld);
         }
-        
 
         internal virtual Decimal GetPersonalAllowance(int numOfPersonalAllowances)
-        {            
+        {
             return PersonalAllowances * numOfPersonalAllowances;
         }
 
@@ -45,7 +44,6 @@ namespace CertiPay.Taxes.State.NewJersey
                 .Select(d => d)
                 .Single();
         }
-        
 
         public class TaxableWithholding
         {

--- a/CertiPay.Taxes.State/New Mexico/TaxTable.cs
+++ b/CertiPay.Taxes.State/New Mexico/TaxTable.cs
@@ -1,41 +1,40 @@
 ﻿using CertiPay.Payroll.Common;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace CertiPay.Taxes.State.NewMexico
 {
     public abstract class TaxTable : TaxTableHeader
     {
-        public override StateOrProvince State { get { return StateOrProvince.NM; } }        
+        public override StateOrProvince State { get { return StateOrProvince.NM; } }
 
-        protected abstract decimal PersonalAllowances { get; }        
+        protected abstract decimal PersonalAllowances { get; }
+
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
-            var taxableWages = frequency.CalculateAnnualized(grossWages);    
+            var taxableWages = frequency.CalculateAnnualized(grossWages);
 
-            taxableWages -= GetPersonalAllowance(personalAllowances);                                    
+            taxableWages -= GetPersonalAllowance(personalAllowances);
 
-            var selected_row = GetTaxWithholding(filingStatus, taxableWages);            
+            var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 
-            var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);            
+            var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);
 
             return frequency.CalculateDeannualized(Math.Max(0, taxWithheld));
         }
-        
 
-        internal virtual Decimal GetPersonalAllowance(int personalAllowances = 1)
+        protected virtual Decimal GetPersonalAllowance(int personalAllowances = 1)
         {
             return personalAllowances * PersonalAllowances;
         }
-        
 
-        internal virtual TaxableWithholding GetTaxWithholding(FilingStatus filingStatus, Decimal taxableWages)
+        protected virtual TaxableWithholding GetTaxWithholding(FilingStatus filingStatus, Decimal taxableWages)
         {
             if (taxableWages < Decimal.Zero) return new TaxableWithholding { };
+
             return
                 TaxableWithholdings
                 .Where(d => d.FilingStatus == filingStatus)
@@ -44,9 +43,8 @@ namespace CertiPay.Taxes.State.NewMexico
                 .Select(d => d)
                 .Single();
         }
-       
 
-        public class TaxableWithholding
+        protected class TaxableWithholding
         {
             public FilingStatus FilingStatus { get; set; } = FilingStatus.Single;
 

--- a/CertiPay.Taxes.State/New Mexico/TaxTable.cs
+++ b/CertiPay.Taxes.State/New Mexico/TaxTable.cs
@@ -13,11 +13,26 @@ namespace CertiPay.Taxes.State.NewMexico
 
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns New Mexico State Withholding when given a non-negative value for gross wages and personal allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 

--- a/CertiPay.Taxes.State/New York/TaxTable.cs
+++ b/CertiPay.Taxes.State/New York/TaxTable.cs
@@ -16,8 +16,23 @@ namespace CertiPay.Taxes.State.NewYork
 
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns New York State Withholding when given a non-negative value for Gross Wages and Dependent Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="region"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="exemptionAllowances"></param>
+        /// <param name="dependentAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, Region region, FilingStatus filingStatus = FilingStatus.Single, int exemptionAllowances = 1, int dependentAllowances = 0)
         {
+
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");        
+            if (dependentAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependentAllowances)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             // Note: Tax exemptions should be handled before we get to this call
@@ -34,6 +49,8 @@ namespace CertiPay.Taxes.State.NewYork
 
             taxableWages -= GetExemptionAllowance(filingStatus, exemptionAllowances);
 
+            if (taxableWages <= 0)
+                return 0;
             //(3) If employees claim dependents other than themselves and/or their spouses, subtract from the amount arrived at in (2) the appropriate dependent amount as set out in column(7) of Table E.
 
             //(4) Determine the amount of tax to be withheld from the applicable payroll line in Tables F, G, or H.

--- a/CertiPay.Taxes.State/NorthCarolina/TaxTable.cs
+++ b/CertiPay.Taxes.State/NorthCarolina/TaxTable.cs
@@ -14,8 +14,20 @@ namespace CertiPay.Taxes.State.NorthCarolina
 
         public abstract Decimal TaxRate { get; }
 
+        /// <summary>
+        /// Returns North Carolina State Withholding when provided with a non-negative value for Gross Wages and Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="taxStatus"></param>
+        /// <param name="allowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus taxStatus = FilingStatus.Single, int allowances = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (allowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(allowances)} cannot be a negative number");
+            
             // Withholding Statuses: Single, Married, Head of Household
 
             var annualized_wages = frequency.CalculateAnnualized(grossWages);

--- a/CertiPay.Taxes.State/NorthDakota/TaxTable.cs
+++ b/CertiPay.Taxes.State/NorthDakota/TaxTable.cs
@@ -13,11 +13,27 @@ namespace CertiPay.Taxes.State.NorthDakota
 
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+
+        /// <summary>
+        /// Returns North Dakota State Withholding when given a non-negative value for gross Wages and personal allowance.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 

--- a/CertiPay.Taxes.State/NorthDakota/TaxTable.cs
+++ b/CertiPay.Taxes.State/NorthDakota/TaxTable.cs
@@ -1,41 +1,40 @@
 ﻿using CertiPay.Payroll.Common;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace CertiPay.Taxes.State.NorthDakota
 {
     public abstract class TaxTable : TaxTableHeader
     {
-        public override StateOrProvince State { get { return StateOrProvince.ND; } }        
+        public override StateOrProvince State { get { return StateOrProvince.ND; } }
 
-        protected abstract decimal PersonalAllowances { get; }        
+        protected abstract decimal PersonalAllowances { get; }
+
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
-            var taxableWages = frequency.CalculateAnnualized(grossWages);    
+            var taxableWages = frequency.CalculateAnnualized(grossWages);
 
-            taxableWages -= GetPersonalAllowance(personalAllowances);                                    
+            taxableWages -= GetPersonalAllowance(personalAllowances);
 
-            var selected_row = GetTaxWithholding(filingStatus, taxableWages);            
+            var selected_row = GetTaxWithholding(filingStatus, taxableWages);
 
-            var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);            
+            var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);
 
             return frequency.CalculateDeannualized(Math.Max(0, taxWithheld)).Round(decimals: 0);
         }
-        
 
-        internal virtual Decimal GetPersonalAllowance(int personalAllowances = 1)
+        protected virtual Decimal GetPersonalAllowance(int personalAllowances = 1)
         {
             return personalAllowances * PersonalAllowances;
         }
-        
 
-        internal virtual TaxableWithholding GetTaxWithholding(FilingStatus filingStatus, Decimal taxableWages)
+        protected virtual TaxableWithholding GetTaxWithholding(FilingStatus filingStatus, Decimal taxableWages)
         {
             if (taxableWages < Decimal.Zero) return new TaxableWithholding { };
+
             return
                 TaxableWithholdings
                 .Where(d => d.FilingStatus == filingStatus)
@@ -44,9 +43,8 @@ namespace CertiPay.Taxes.State.NorthDakota
                 .Select(d => d)
                 .Single();
         }
-       
 
-        public class TaxableWithholding
+        protected class TaxableWithholding
         {
             public FilingStatus FilingStatus { get; set; } = FilingStatus.Single;
 

--- a/CertiPay.Taxes.State/Ohio/TaxTable.cs
+++ b/CertiPay.Taxes.State/Ohio/TaxTable.cs
@@ -16,11 +16,25 @@ namespace CertiPay.Taxes.State.Ohio
 
         protected abstract Decimal Exemption { get; }
 
+        /// <summary>
+        /// Returns Ohio State Withholding when given a non-negative number for gross wages and exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (exemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(exemptions)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);
 
             taxableWages -= GetExemptions(exemptions);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(taxableWages);
 

--- a/CertiPay.Taxes.State/Oklahoma/TaxTable2017.cs
+++ b/CertiPay.Taxes.State/Oklahoma/TaxTable2017.cs
@@ -9,6 +9,15 @@ namespace CertiPay.Taxes.State.Oklahoma
 
         public override decimal SUI_Wage_Base { get; internal set; } = 17700;
 
+
+        /// <summary>
+        /// Returns Oklahoma State Withholding when given a non-negative value for Gross Wages and Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="isMarried"></param>
+        /// <param name="allowances"></param>
+        /// <returns></returns>
         public override Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, Boolean isMarried = false, int allowances = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
@@ -23,7 +32,11 @@ namespace CertiPay.Taxes.State.Oklahoma
 
             // Use the appropriate rate to figure the amount to be withheld
 
+
             Decimal flat_amount = 0, bracket_floor = 0, percentage = 0m;
+
+            if (taxable_earnings <= 0)
+                return 0;
 
             if (isMarried)
             {

--- a/CertiPay.Taxes.State/Oregon/TaxTable.cs
+++ b/CertiPay.Taxes.State/Oregon/TaxTable.cs
@@ -17,9 +17,22 @@ namespace CertiPay.Taxes.State.Oregon
 
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Oregon State Withholding when given a non-negative value for Federal Withholding, Gross Wages and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="federalWithholding"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, decimal federalWithholding, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (federalWithholding < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(federalWithholding)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+
 
             var annualWages = frequency.CalculateAnnualized(grossWages);
             var taxableWages = annualWages;

--- a/CertiPay.Taxes.State/Rhode Island/TaxTable.cs
+++ b/CertiPay.Taxes.State/Rhode Island/TaxTable.cs
@@ -16,11 +16,25 @@ namespace CertiPay.Taxes.State.RhodeIsland
         
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Rhode Island State Withholding when given a non-negative values for Gross Wages and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="personalAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int personalAllowances = 1)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            
             var taxableWages = frequency.CalculateAnnualized(grossWages);
                      
-            taxableWages -= GetPersonalAllowance(taxableWages, personalAllowances);          
+            taxableWages -= GetPersonalAllowance(taxableWages, personalAllowances);
+
+            if (taxableWages <= 0)
+                return 0;
 
             var selected_row = GetTaxWithholding(taxableWages);
 

--- a/CertiPay.Taxes.State/SouthCarolina/TaxTable.cs
+++ b/CertiPay.Taxes.State/SouthCarolina/TaxTable.cs
@@ -17,6 +17,8 @@ namespace CertiPay.Taxes.State.SouthCarolina
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions = 0)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var annualized_wages = frequency.CalculateAnnualized(grossWages);
 
             // If zero exemptions were claimed, do not deduct standard deduction

--- a/CertiPay.Taxes.State/SouthCarolina/TaxTable.cs
+++ b/CertiPay.Taxes.State/SouthCarolina/TaxTable.cs
@@ -15,10 +15,19 @@ namespace CertiPay.Taxes.State.SouthCarolina
 
         public abstract IEnumerable<TableRow> Table { get; }
 
+        /// <summary>
+        /// Returns South Carolina Withholding when given a non-negative value for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
-
+            if (exemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(exemptions)} cannot be a negative number");
+            
             var annualized_wages = frequency.CalculateAnnualized(grossWages);
 
             // If zero exemptions were claimed, do not deduct standard deduction
@@ -29,6 +38,9 @@ namespace CertiPay.Taxes.State.SouthCarolina
 
                 annualized_wages -= (exemptions * ExemptionValue + StandardDeduction(annualized_wages));
             }
+
+            if (annualized_wages <= 0)
+                return 0;
 
             var tax_table =
                 Table

--- a/CertiPay.Taxes.State/Utah/TaxTable.cs
+++ b/CertiPay.Taxes.State/Utah/TaxTable.cs
@@ -50,6 +50,15 @@ namespace CertiPay.Taxes.State.Utah
             }
         }
 
+        /// <summary>
+        /// Returns Utah State Withholding when given a non-negative value for gross wages and exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus, int exemptions = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/Vermont/TaxTable.cs
+++ b/CertiPay.Taxes.State/Vermont/TaxTable.cs
@@ -14,10 +14,15 @@ namespace CertiPay.Taxes.State.Vermont
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int withholdingAllowances = 1, decimal nonresidentPercentage = 0.00m)
         {
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);            
 
             taxableWages -= GetWitholdingAllowance(withholdingAllowances);
-                                    
+
+            if (taxableWages <= 0)
+                return 0;
+
             var selected_row = GetTaxWithholding(filingStatus, taxableWages);            
 
             var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);

--- a/CertiPay.Taxes.State/Vermont/TaxTable.cs
+++ b/CertiPay.Taxes.State/Vermont/TaxTable.cs
@@ -12,9 +12,22 @@ namespace CertiPay.Taxes.State.Vermont
         public abstract decimal AllowanceValue { get; }
         public abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Vermont State Withholding when given a non-negative value for Gross Wages, Withholding Allowans and Non Resident Percentage.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="withholdingAllowances"></param>
+        /// <param name="nonresidentPercentage"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int withholdingAllowances = 1, decimal nonresidentPercentage = 0.00m)
         {
-            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");            
+            if (withholdingAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(withholdingAllowances)} cannot be a negative number");
+            if (nonresidentPercentage < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(withholdingAllowances)} cannot be a negative number");
+
 
             var taxableWages = frequency.CalculateAnnualized(grossWages);            
 

--- a/CertiPay.Taxes.State/Virginia/TaxTable.cs
+++ b/CertiPay.Taxes.State/Virginia/TaxTable.cs
@@ -23,7 +23,11 @@ namespace CertiPay.Taxes.State.Virginia
 
             decimal annualized_taxes = 0;
 
-            if(annualized_wages < 3000)
+            if (annualized_wages <= 0)
+            {
+                return 0;
+            }
+            else if(annualized_wages < 3000)
             {
                 annualized_taxes = annualized_wages * 0.02m;
             }

--- a/CertiPay.Taxes.State/Virginia/TaxTable.cs
+++ b/CertiPay.Taxes.State/Virginia/TaxTable.cs
@@ -9,9 +9,20 @@ namespace CertiPay.Taxes.State.Virginia
     {
         public override StateOrProvince State { get { return StateOrProvince.VA; } }
 
+        /// <summary>
+        /// Returns Virgina Tax Withholding when given a non-negative value for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, int exemptions = 0)
-        {
-            var annualized_wages = frequency.CalculateAnnualized(grossWages);
+        { 
+        if (grossWages <Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+        if (exemptions < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(exemptions)} cannot be a negative number");
+
+        var annualized_wages = frequency.CalculateAnnualized(grossWages);
 
             // G(P) - [$3,000 + (E1 x $930) + (E2 x $800)] = T
 

--- a/CertiPay.Taxes.State/WestVirginia/TaxTable.cs
+++ b/CertiPay.Taxes.State/WestVirginia/TaxTable.cs
@@ -29,6 +29,16 @@ namespace CertiPay.Taxes.State.WestVirginia
 
         public Decimal ExemptionValue { get; } = 2000;
 
+
+        /// <summary>
+        /// Returns West Virginia State Withholding when given a non-negative value for Gross Wages and Exemptions.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="status"></param>
+        /// <param name="exemptions"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus status = FilingStatus.Two_Earnings, int exemptions = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");

--- a/CertiPay.Taxes.State/WestVirginia/TaxTable.cs
+++ b/CertiPay.Taxes.State/WestVirginia/TaxTable.cs
@@ -36,7 +36,10 @@ namespace CertiPay.Taxes.State.WestVirginia
 
             var annualized_wages = frequency.CalculateAnnualized(grossWages);
 
-            annualized_wages -= (exemptions * ExemptionValue);
+            annualized_wages -= exemptions * ExemptionValue;
+
+            if (annualized_wages <= 0)
+                return 0;
 
             var bracket =
                 Brackets

--- a/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
+++ b/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
@@ -15,9 +15,22 @@ namespace CertiPay.Taxes.State.Wisconsin
 
         protected abstract IEnumerable<TaxableWithholding> TaxableWithholdings { get; }
 
+        /// <summary>
+        /// Returns Wisconsin State Withholding when given a non-negative value for Gross Wages, Dependent Allowances and Personal Allowances.
+        /// </summary>
+        /// <param name="grossWages"></param>
+        /// <param name="frequency"></param>
+        /// <param name="filingStatus"></param>
+        /// <param name="personalAllowances"></param>
+        /// <param name="dependentAllowances"></param>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when Negative Values entered.</exception>
+        /// <returns></returns>
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1, int dependentAllowances = 0)
         {
             if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            if (personalAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(personalAllowances)} cannot be a negative number");
+            if (dependentAllowances < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(dependentAllowances)} cannot be a negative number");
+
             var taxableWages = frequency.CalculateAnnualized(grossWages);            
 
             taxableWages -= GetStandardDeduction(filingStatus, taxableWages);

--- a/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
+++ b/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
@@ -17,10 +17,15 @@ namespace CertiPay.Taxes.State.Wisconsin
 
         public virtual Decimal Calculate(Decimal grossWages, PayrollFrequency frequency, FilingStatus filingStatus = FilingStatus.Single, int personalAllowances = 1, int dependentAllowances = 0)
         {
-            var taxableWages = frequency.CalculateAnnualized(grossWages);
+            if (grossWages < Decimal.Zero) throw new ArgumentOutOfRangeException($"{nameof(grossWages)} cannot be a negative number");
+            var taxableWages = frequency.CalculateAnnualized(grossWages);            
 
             taxableWages -= GetStandardDeduction(filingStatus, taxableWages);
             taxableWages -= GetPersonalAllowance(personalAllowances);
+
+            if (taxableWages <= 0)
+                return 0;
+
             var selected_row = GetTaxWithholding(taxableWages);
 
             var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);

--- a/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
+++ b/CertiPay.Taxes.State/Wisconsin/TaxTable.cs
@@ -1,7 +1,6 @@
 ﻿using CertiPay.Payroll.Common;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
 using System.Linq;
 
 namespace CertiPay.Taxes.State.Wisconsin
@@ -27,7 +26,6 @@ namespace CertiPay.Taxes.State.Wisconsin
             var taxWithheld = selected_row.TaxBase + ((taxableWages - selected_row.StartingAmount) * selected_row.TaxRate);
 
             return frequency.CalculateDeannualized(Math.Max(0, taxWithheld));
-
         }
 
         protected virtual Decimal GetStandardDeduction(FilingStatus filingStatus, decimal wages)
@@ -35,7 +33,7 @@ namespace CertiPay.Taxes.State.Wisconsin
             var deduction =
                 StandardDeductions
                 .Where(d => d.FilingStatus == filingStatus)
-                .Where(d => d.StartingAmount <= wages && wages < d.MaximumWage)                
+                .Where(d => d.StartingAmount <= wages && wages < d.MaximumWage)
                 .Select(d => d)
                 .Single();
 
@@ -50,13 +48,12 @@ namespace CertiPay.Taxes.State.Wisconsin
             return PersonalAllowances * personalAllowances;
         }
 
-
         protected virtual TaxableWithholding GetTaxWithholding(Decimal taxableWages)
         {
             if (taxableWages < Decimal.Zero) return new TaxableWithholding { };
 
             return
-                TaxableWithholdings                
+                TaxableWithholdings
                 .Where(d => d.StartingAmount <= taxableWages)
                 .Where(d => taxableWages < d.MaximumWage)
                 .Select(d => d)
@@ -66,15 +63,18 @@ namespace CertiPay.Taxes.State.Wisconsin
         protected class StandardDeduction
         {
             public FilingStatus FilingStatus { get; set; }
+
             public Decimal StartingAmount { get; set; }
+
             public Decimal MaximumWage { get; set; }
+
             public Decimal Amount { get; set; }
+
             public Decimal Percentage { get; set; } = Decimal.Zero;
         }
 
         protected class TaxableWithholding
-        {            
-
+        {
             public Decimal TaxBase { get; set; }
 
             public Decimal StartingAmount { get; set; }
@@ -84,6 +84,4 @@ namespace CertiPay.Taxes.State.Wisconsin
             public Decimal TaxRate { get; set; }
         }
     }
-
-   
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@
 #   - Section names should be unique on each level
 
 # version format
-version: 2017.0.{build}
+version: 2017.1.{build}
 
 shallow_clone: true
 


### PR DESCRIPTION
Some inputs cause the calculations to explode in unexpected ways.

For instance, if calculating a simple weekly check for $25 for Arkansas, it would bomb because the allowance values push that negative, causing the other lookups to fail. 

States
- [ ] AL
- [x] AR
- [ ] AZ
- [ ] CA
- [ ] CO
- [ ] CT
- [ ] DE
- [ ] GA
- [ ] HI
- [ ] IA
- [ ] ID
- [ ] IL
- [ ] IN
- [ ] KS
- [ ] KY
- [ ] LA
- [ ] MA
- [ ] ME
- [ ] MI
- [ ] MN
- [ ] MO
- [ ] MS
- [ ] MT
- [ ] NC
- [ ] ND
- [ ] NE
- [ ] NJ
- [ ] NY
- [ ] OH
- [ ] OK
- [ ] OR
- [ ] RI
- [ ] SC
- [ ] UT
- [ ] VA
- [ ] VT
- [ ] WI
- [ ] WV